### PR TITLE
Set site-url to lung.fish and emit canonical links

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -4,6 +4,9 @@ project:
 
 website:
   title: "𓆞 lung.fish Data Explorer"
+  # The site is served under the lung.fish custom domain, not the
+  # Lungfish-science.github.io address Quarto infers from the publish target.
+  site-url: https://lung.fish/wastewater-dashboard
   repo-url: https://github.com/Lungfish-science/wastewater-dashboard
   navbar:
     right:
@@ -72,6 +75,7 @@ format:
       - brand
     css: styles.css
     toc: true
+    canonical-url: true
 
 # execute:
 #   freeze: auto


### PR DESCRIPTION
## Problem

Google Search Console reports **"Duplicate without user-selected canonical"** for `https://lung.fish/wastewater-dashboard/index.html`.

Two things combine to cause it:

1. **No canonical links anywhere.** I checked all six published pages (`/`, `index.html`, `dashboard1.html`, `dashboard2.html`, `about.html`, `acknowledgements.html`) — none carries a `<link rel="canonical">`. Meanwhile `/wastewater-dashboard/index.html` and `/wastewater-dashboard/` serve **byte-identical** content (verified: same SHA). With identical content at two URLs and no canonical declared, Google has to pick a preferred URL on our behalf — which is exactly what that error means.

2. **The sitemap points at the wrong domain.** This site is published with `quarto publish gh-pages`, so Quarto inferred its URL from the GitHub Pages address. Every one of the five URLs in `sitemap.xml` uses `https://Lungfish-science.github.io/wastewater-dashboard/...`, and that host now 301-redirects to `lung.fish`. So the sitemap actively submits five redirecting URLs to Google, and it submits the `index.html` form specifically — the very duplicate that got flagged.

## Change

Two lines in `_quarto.yml` (plus a clarifying comment):

- `site-url: https://lung.fish/wastewater-dashboard` under `website:` — corrects the sitemap to the domain the site is actually served on.
- `canonical-url: true` under `format: html:` — makes every page declare its own canonical. This option requires a known `site-url`, which is why both are needed together.
